### PR TITLE
Replace `gcvt' with `snprintf'

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -117,7 +117,7 @@ void _display( const int padding, const int option, const char * fmt, ... )
 			if( * fmt == 'f' ) {
 				double f = va_arg( args, double );
 				char f_str[ 10 ];
-				gcvt( f, sizeof( f_str ), f_str );
+				snprintf( f_str, sizeof( f_str ), "%f", f );
 				res_str[ res_ctr ] = '\0';
 				strcat( res_str, f_str );
 				res_ctr = strlen( res_str );


### PR DESCRIPTION
FreeBSD doesn't have `gcvt'. This change replaces the call to that with
a call to `snprintf'. 

Related Issue: #4 