### PR TITLE
Mostly cosmetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ I recommend the *Mononoki Nerd font* for the characters, and *Overpass Mono Nerd
 
 The basic usage is similar to the native *ls* command, and for the options, take a look at:
 
-`ls_extended help`
+`ls_extended --help`
 
 Where ls_extended is the binary of this program which must be built.
 

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ mkdir -p "bin"
 
 find src -name "*.c" | grep -v "tests" | grep -v "main.c" | while read -r src_file; do
 	echo "Compiling: $src_file ..."
-	$compiler -O2 -std=c11 -c $src_file -o buildfiles/$src_file.o -I/usr/local/include
+	$compiler -O2 -std=gnu99 -c $src_file -o buildfiles/$src_file.o -I/usr/local/include
 	if ! [[ $? == 0 ]]; then
 		break
 	fi

--- a/include/ls.h
+++ b/include/ls.h
@@ -12,7 +12,6 @@
 #define LS_H
 
 #if defined __linux__ && defined __GNUC__ && !defined __clang__
-#define _DEFAULT_SOURCE
 #endif
 
 #include <stdlib.h>

--- a/include/ls.h
+++ b/include/ls.h
@@ -11,9 +11,6 @@
 #ifndef LS_H
 #define LS_H
 
-#if defined __linux__ && defined __GNUC__ && !defined __clang__
-#endif
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <sys/ioctl.h>

--- a/src/core.c
+++ b/src/core.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -143,7 +144,7 @@ void _display( const int global_padding, const int option, const char * fmt, ...
 			if( * fmt == 'l' && *( fmt + 1 ) != '\0' && *( fmt + 1 ) == 'l' && *( fmt + 2 ) != '\0' && *( fmt + 2 ) == 'u' ) {
 				uint64_t llu = va_arg( args, uint64_t );
 				char st_str[ 30 ];
-				snprintf( st_str, sizeof( st_str ), "%lu", llu );
+				snprintf( st_str, sizeof( st_str ), "%" PRIu64, llu );
 				res_str[ res_ctr ] = '\0';
 				strcat( res_str, st_str );
 				res_ctr = strlen( res_str );

--- a/src/core.c
+++ b/src/core.c
@@ -143,7 +143,7 @@ void _display( const int global_padding, const int option, const char * fmt, ...
 			if( * fmt == 'l' && *( fmt + 1 ) != '\0' && *( fmt + 1 ) == 'l' && *( fmt + 2 ) != '\0' && *( fmt + 2 ) == 'u' ) {
 				uint64_t llu = va_arg( args, uint64_t );
 				char st_str[ 30 ];
-				snprintf( st_str, sizeof( st_str ), "%llu", llu );
+				snprintf( st_str, sizeof( st_str ), "%lu", llu );
 				res_str[ res_ctr ] = '\0';
 				strcat( res_str, st_str );
 				res_ctr = strlen( res_str );


### PR DESCRIPTION
src/core.c - this is tricky as previous formatting was giving me a warning on 2/3 of my systems.
include/ls.h - this change may be a bit far fetched, but block seems redundant.
build.sh - probably better to use gnu99 with functions like strcasecmp.