### PR TITLE
Added support for '1'-flag to always print results in 1 column.

### DIFF
--- a/include/cmdopts.h
+++ b/include/cmdopts.h
@@ -25,6 +25,7 @@ static const size_t OPT_I = 1 << 6;
 static const size_t OPT_L = 1 << 7;
 static const size_t OPT_T = 1 << 8;
 static const size_t OPT_S = 1 << 9;
+static const size_t OPT_1 = 1 << 10;
 
 size_t get_cmd_opts( const int argc, const char ** argv, char * location );
 

--- a/src/cmdopts.c
+++ b/src/cmdopts.c
@@ -38,6 +38,7 @@ size_t get_cmd_opts( const int argc, const char ** argv, char * location )
 			else if( argv[ i ][ j ] == 'l' ) flags |= OPT_L;
 			else if( argv[ i ][ j ] == 't' ) flags |= OPT_T;
 			else if( argv[ i ][ j ] == 's' ) flags |= OPT_S;
+			else if( argv[ i ][ j ] == '1' ) flags |= OPT_1;
 		}
 	}
 

--- a/src/ls.c
+++ b/src/ls.c
@@ -78,7 +78,7 @@ int ls( const struct winsize * ws, const char * loc, size_t flags )
 	// The color codes are not displayed but do account for padding ( i guess ),
 	// and hence must be manually handled
 	int max_items_per_line = ( int ) ( ws->ws_col - 1 ) / ( max_len_in_files - 14 );
-	if( max_items_per_line < 1 ) max_items_per_line = 1;
+	if( ( flags & OPT_1 ) || max_items_per_line < 1 ) max_items_per_line = 1;
 
 	int items_per_line_ctr = 0;
 


### PR DESCRIPTION
I added a new option `OPT_1` in cmdopts. If set, the `max_items_per_line` variable in ls.c will be set to 1. As a result the output will always be printed using one column.

This corresponds to the functionality of the same flag in the original `ls` command.