### PR TITLE
Fixed Buffer Overflow in src/ls.c

### DIFF
--- a/src/ls.c
+++ b/src/ls.c
@@ -47,7 +47,13 @@ static void sort_list_dirs_first( struct str_vec * locs );
 
 int ls( const struct winsize * ws, const char * loc, size_t flags, int loc_count )
 {
-	char final_loc[ 1024 ];
+	const size_t loc_size = 1024;
+	char final_loc[ loc_size ];
+
+	if((strlen(loc) + 1) > loc_size) {
+		return EXIT_FAILURE;
+	}
+
 	if( strcmp( loc, "\0" ) == 0 ) strcpy( final_loc, "." );
 	else strcpy( final_loc, loc );
 


### PR DESCRIPTION
The function ls in src/ls.c is vulnerable to a buffer overflow due to insufficient bound checks of the loc argument. 
It is copied to the fixed-size buffer final_loc, holding 1024 bytes at max. Any input exceeding this bounds therefore leads to a corruption of neighboring memory regions. 

Steps to reproduce (requires gdb and python3):
  (in project's root directory)
$ ./build.sh
$ gdb --args ./bin/ls_extended $(python3 -c 'print("a" * 2000)')
(gdb) run

The stack protection introduced by gcc will then detect a stack smash attack. 