### PR TITLE
Strip out CR's from filenames 

### DIFF
--- a/src/ls.c
+++ b/src/ls.c
@@ -71,7 +71,11 @@ int ls( const struct winsize * ws, const char * loc, size_t flags, int loc_count
 	struct stat tmp_st;
 	int tmp_st_res = stat( final_loc, & tmp_st );
 	if( tmp_st_res != 0 ) {
-		display( "{p}Something went wrong in fetching information of {r}%s{0}, {p}error{0}: {s}%d\n", final_loc, errno );
+		if(errno == ENOENT){
+			display( "{s}Given path {r}%s{s} does not exist {0}({p}ENOENT{0})\n", final_loc );
+		} else {
+			display( "{p}Something went wrong in fetching information of {r}%s{0}, {p}error{0}: {s}%d\n", final_loc, errno );
+		}
 		return errno;
 	}
 	if( !S_ISDIR( tmp_st.st_mode ) ) {
@@ -187,6 +191,12 @@ static int display_loc_info( const char * path, const char * loc, size_t flags, 
 			return SUCCESS;
 		}
 
+		char* loc_mut = (char*)loc;
+		for(int i = 0; i < strlen(loc); i++){
+			if(loc[i] == '\r'){
+				loc_mut[i] = '?';
+			}
+		}
 		display_padded( max_file_len + utf_spaces, "{g}%s %s{0}", icon, loc );
 		return SUCCESS;
 	}
@@ -246,7 +256,15 @@ static int display_loc_info( const char * path, const char * loc, size_t flags, 
 	// file/folder name
 	if( S_ISDIR( stats.st.st_mode ) ) display( "\t{b}%s %s", icon, loc );
 	else if( S_ISLNK( stats.st.st_mode ) ) display( "\t{y}%s %s{0}" , icon, loc );
-	else display( "\t{g}%s %s", icon, loc );
+	else {
+		char* loc_mut = (char*)loc;
+		for(int i = 0; i < strlen(loc); i++){
+			if(loc[i] == '\r'){
+				loc_mut[i] = '?';
+			}
+		}
+		display( "\t{g}%s %s", icon, loc );
+	}
 
 	// link info for links
 	if( S_ISLNK( stats.st.st_mode ) ) {


### PR DESCRIPTION
Closes #29

Also adds a more informative error message in case of ENOENT ("something went wrong when fetching info" is somewhat vague)